### PR TITLE
fix(intelli-ai-engine): [HOM-194] 修复百炼 minimax m2.5 test 报错且错误信息不可见

### DIFF
--- a/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/AIServiceException.java
+++ b/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/AIServiceException.java
@@ -131,14 +131,48 @@ public class AIServiceException extends Exception {
             return AICommonBundle.message("error.ai.service.call.failed", e.getMessage());
         }
 
+        // [HOM-194] 之前 INVALID_API_KEY / RATE_LIMIT / SERVICE_UNAVAILABLE / INVALID_RESPONSE
+        // 分支只返回通用 i18n 文案, 把 BlockingRequestExecutor 透传上来的真实 API 错误体
+        // (例如百炼的 "The value of the enable_thinking parameter is restricted to True")
+        // 完全丢弃, 用户在 UI 弹窗里只能看到 "服务返回的数据格式错误" 这种无信息的提示.
+        // 这里改成: 只要 underlying message 非空, 就走带 detail 的 bundle key 把原文拼进去;
+        // 否则保持原有通用文案, 行为向后兼容.
+        String detail = sanitize(e.getMessage());
+        boolean hasDetail = !detail.isEmpty();
+
         return switch (errorCode) {
-            case INVALID_API_KEY -> AICommonBundle.message("error.ai.service.invalid.api.key");
-            case RATE_LIMIT -> AICommonBundle.message("error.ai.service.rate.limit");
-            case SERVICE_UNAVAILABLE -> AICommonBundle.message("error.ai.service.unavailable");
+            case INVALID_API_KEY -> hasDetail
+                ? AICommonBundle.message("error.ai.service.invalid.api.key.with.detail", detail)
+                : AICommonBundle.message("error.ai.service.invalid.api.key");
+            case RATE_LIMIT -> hasDetail
+                ? AICommonBundle.message("error.ai.service.rate.limit.with.detail", detail)
+                : AICommonBundle.message("error.ai.service.rate.limit");
+            case SERVICE_UNAVAILABLE -> hasDetail
+                ? AICommonBundle.message("error.ai.service.unavailable.with.detail", detail)
+                : AICommonBundle.message("error.ai.service.unavailable");
             case NETWORK_ERROR -> AICommonBundle.message("error.ai.service.network.error");
-            case CONFIGURATION_ERROR -> AICommonBundle.message("error.ai.service.configuration.error", e.getMessage());
-            case INVALID_RESPONSE -> AICommonBundle.message("error.ai.service.invalid.response");
-            default -> AICommonBundle.message("error.ai.service.call.failed.with.suggestion", e.getMessage());
+            case CONFIGURATION_ERROR -> AICommonBundle.message("error.ai.service.configuration.error", detail);
+            case INVALID_RESPONSE -> hasDetail
+                ? AICommonBundle.message("error.ai.service.invalid.response.with.detail", detail)
+                : AICommonBundle.message("error.ai.service.invalid.response");
+            default -> AICommonBundle.message("error.ai.service.call.failed.with.suggestion", detail);
         };
+    }
+
+    /**
+     * 对异常 message 做基础清洗, 仅去除前后空白并把 null 归一为空串
+     * <p>
+     * 注意: 真正的凭据脱敏发生在 BlockingRequestExecutor.sanitizeForUser, 这里只做空值兜底,
+     * 避免把 "null" 字面量写进 i18n 文案.
+     *
+     * @param msg 异常 message, 允许为 null
+     * @return 清洗后的字符串, 永不为 null
+     */
+    @org.jetbrains.annotations.NotNull
+    private static String sanitize(@org.jetbrains.annotations.Nullable String msg) {
+        if (msg == null) {
+            return "";
+        }
+        return msg.trim();
     }
 }

--- a/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/provider/AICompatibleProvider.java
+++ b/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/provider/AICompatibleProvider.java
@@ -390,13 +390,14 @@ public abstract class AICompatibleProvider implements AIServiceProvider {
         JsonObject body = new JsonObject();
         body.addProperty("model", config.modelName);
 
-        if (!enableThinking) {
-            // 如果设置为关闭思考, 有些思考模型会报错, 所以需要强制设置为开启思考模式
-            if (config.modelName.contains("think")) {
-                enableThinking = true;
-            }
-            body.addProperty("think", enableThinking);
-            body.addProperty("enable_thinking", enableThinking);
+        // [HOM-194] 仅在需要启用思考模式时显式发送 enable_thinking: true.
+        // 部分 OpenAI 兼容服务 (如阿里百炼的 MiniMax-M2.5) 严格校验 enable_thinking
+        // 参数: 若显式传入 false 会直接以 HTTP 400 返回
+        // "The value of the enable_thinking parameter is restricted to True".
+        // 因此默认不写入该字段, 交由后端默认行为处理; 同时移除非标准的 "think" 字段,
+        // 避免对其它 OpenAI 兼容厂商造成兼容性风险.
+        if (enableThinking || config.modelName.contains("think")) {
+            body.addProperty("enable_thinking", true);
         }
         body.addProperty("stream", stream);
         body.add("messages", messagesArray);

--- a/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/provider/completion/BlockingRequestExecutor.java
+++ b/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ai/provider/completion/BlockingRequestExecutor.java
@@ -11,9 +11,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 
 import dev.dong4j.zeka.stack.idea.plugin.common.ai.AIResponseListener;
 import dev.dong4j.zeka.stack.idea.plugin.common.ai.AIServiceException;
@@ -123,7 +125,12 @@ public class BlockingRequestExecutor {
             byte[] requestBodyBytes = requestBody.getBytes(StandardCharsets.UTF_8);
             final int contentLength = requestBodyBytes.length;
 
+            // [HOM-194] 关闭 IDEA 自带的 4xx/5xx 自动抛异常逻辑, 由我们手动在回调内读取
+            // error stream 的原始 body 并写入 HttpStatusException.message,
+            // 否则上层只能看到 "Request failed with status code 400" 这类无信息的
+            // 默认描述, API 真正的错误体 (例如百炼的 InvalidParameter 提示) 会被吞掉.
             String responseBody = HttpRequests.post(url, "application/json")
+                .throwStatusCodeException(false)
                 .tuner(connection -> {
                     HttpURLConnection conn = (HttpURLConnection) connection;
                     connectionTuner.accept(conn, apiKey);
@@ -132,7 +139,19 @@ public class BlockingRequestExecutor {
                 })
                 .connect(request -> {
                     request.write(requestBody);
-                    return request.readString();
+                    HttpURLConnection conn = (HttpURLConnection) request.getConnection();
+                    int statusCode = conn.getResponseCode();
+                    if (statusCode >= 200 && statusCode < 300) {
+                        return request.readString();
+                    }
+                    // 非 2xx 时务必使用 getErrorStream(): getInputStream() 在 4xx 下会直接抛 IOException
+                    // 导致拿不到 body. 读到的 body 做截断 + 简单脱敏后塞进 HttpStatusException.message,
+                    // 供上层 (AIServiceException.build / UI 弹窗 / idea.log) 透出.
+                    String errorBody = readErrorBody(conn);
+                    String detail = sanitizeForUser(errorBody);
+                    throw new HttpRequests.HttpStatusException(
+                        "HTTP " + statusCode + ": " + (detail.isEmpty() ? "(empty response body)" : detail),
+                        statusCode, url);
                 });
 
             logResponse(listener, responseBody, validation);
@@ -146,18 +165,81 @@ public class BlockingRequestExecutor {
             throw new AIServiceException("Invalid response from AI service",
                                          AIServiceException.ErrorCode.INVALID_RESPONSE);
         } catch (HttpRequests.HttpStatusException e) {
+            // [HOM-194] 显式区分 400 / 404 (配置类错误, 应当带 detail 给用户)
+            // 与 401 / 403 (鉴权类) / 429 (限流) / 5xx (服务端). 之前所有非显式分支被
+            // 错误地折叠到 INVALID_RESPONSE, 进而被 AIServiceException.build() 翻译成
+            // "服务返回的数据格式错误", 把真正的 API 错误体彻底丢失.
             AIServiceException.ErrorCode code = switch (e.getStatusCode()) {
-                case 401 -> AIServiceException.ErrorCode.INVALID_API_KEY;
+                case 400, 404 -> AIServiceException.ErrorCode.CONFIGURATION_ERROR;
+                case 401, 403 -> AIServiceException.ErrorCode.INVALID_API_KEY;
                 case 429 -> AIServiceException.ErrorCode.RATE_LIMIT;
                 case 500, 502, 503, 504 -> AIServiceException.ErrorCode.SERVICE_UNAVAILABLE;
                 default -> AIServiceException.ErrorCode.INVALID_RESPONSE;
             };
-            throw new AIServiceException("HTTP error: " + e.getMessage(), code, e);
+            // e.getMessage() 已经包含 "HTTP <code>: <body>", 直接透传, 不再额外包一层 "HTTP error:"
+            throw new AIServiceException(e.getMessage(), code, e);
         } catch (IOException e) {
             final String message = getErrorString(e);
             throw new AIServiceException("未知错误: " + message,
                                          AIServiceException.ErrorCode.UNKNOWN_ERROR, e);
         }
+    }
+
+    /** error body 最大保留长度, 避免 4MB 的 HTML 错误页撑爆日志和弹窗. */
+    private static final int MAX_ERROR_BODY_LEN = 4096;
+
+    /** 用于脱敏 Authorization / API Key 出现在错误体 (或上游回显请求) 中的极小概率情况. */
+    private static final Pattern AUTH_HEADER_PATTERN =
+        Pattern.compile("(?i)(authorization\\s*[:=]\\s*['\"]?)(bearer\\s+)?[A-Za-z0-9._\\-]+");
+    private static final Pattern API_KEY_FIELD_PATTERN =
+        Pattern.compile("(?i)(\"?api[_-]?key\"?\\s*[:=]\\s*['\"])([^'\"]+)(['\"])");
+    private static final Pattern SK_TOKEN_PATTERN =
+        Pattern.compile("sk-[A-Za-z0-9]{6,}");
+
+    /**
+     * 读取 HttpURLConnection 的 error stream
+     * <p>
+     * 必须在 4xx/5xx 状态下调用. getErrorStream() 在没有 body 时返回 null, 这里做防御.
+     * 任何 IO 异常都被吞掉返回空串, 因为我们已经处于错误处理路径, 不想把读 body 失败
+     * 再当成另一个错误向上抛.
+     *
+     * @param conn 已经发起请求, 且 responseCode 处于 4xx/5xx 的 HttpURLConnection
+     * @return error body 字符串, 失败或无 body 时返回空串
+     */
+    @NotNull
+    private static String readErrorBody(@NotNull HttpURLConnection conn) {
+        try (InputStream stream = conn.getErrorStream()) {
+            if (stream == null) {
+                return "";
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            return "";
+        }
+    }
+
+    /**
+     * 对透出给用户的错误内容做截断 + 凭据脱敏
+     * <p>
+     * 截断到 {@value #MAX_ERROR_BODY_LEN} 字符, 同时屏蔽可能出现的 Authorization 头,
+     * api_key 字段和 OpenAI 风格的 sk-xxxx token, 避免敏感信息进入 idea.log / 弹窗.
+     *
+     * @param raw 原始 body, 允许为 null
+     * @return 清洗后的字符串, 总长度不超过 MAX_ERROR_BODY_LEN + 截断提示
+     */
+    @NotNull
+    private static String sanitizeForUser(@Nullable String raw) {
+        if (raw == null || raw.isEmpty()) {
+            return "";
+        }
+        String redacted = AUTH_HEADER_PATTERN.matcher(raw).replaceAll("$1***");
+        redacted = API_KEY_FIELD_PATTERN.matcher(redacted).replaceAll("$1***$3");
+        redacted = SK_TOKEN_PATTERN.matcher(redacted).replaceAll("sk-***");
+        if (redacted.length() <= MAX_ERROR_BODY_LEN) {
+            return redacted;
+        }
+        return redacted.substring(0, MAX_ERROR_BODY_LEN)
+               + "...[truncated " + (redacted.length() - MAX_ERROR_BODY_LEN) + " chars]";
     }
 
     /**

--- a/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ui/AIProviderConfigController.java
+++ b/intelli-ai-engine/src/main/java/dev/dong4j/zeka/stack/idea/plugin/common/ui/AIProviderConfigController.java
@@ -1,6 +1,8 @@
 package dev.dong4j.zeka.stack.idea.plugin.common.ui;
 
+import com.intellij.ide.actions.RevealFileAction;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.PathManager;
 import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.components.JBLabel;
 import com.intellij.ui.components.JBTextField;
@@ -9,7 +11,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.Component;
+import java.awt.Toolkit;
 import java.awt.Window;
+import java.awt.datatransfer.StringSelection;
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,6 +51,7 @@ import dev.dong4j.zeka.stack.idea.plugin.common.ui.component.StatusIndicatorButt
 import dev.dong4j.zeka.stack.idea.plugin.common.util.AICommonBundle;
 import dev.dong4j.zeka.stack.idea.plugin.kit.StorageUtil;
 import icons.AICommonIcons;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * AI 提供商配置控制器
@@ -60,6 +66,7 @@ import icons.AICommonIcons;
  * @date 2025.11.30
  * @since 1.0.0
  */
+@Slf4j
 public final class AIProviderConfigController {
 
     /** 负责管理 AI 身份凭证的工具类实例 */
@@ -490,10 +497,9 @@ public final class AIProviderConfigController {
                         configurationVerified = false;
                         updateTestButtonState();
                         removeAvailableProvider(testConfig.credentialId);
-                        JOptionPane.showMessageDialog(resolveDialogParent(),
-                                                      result.getFullErrorMessage(),
-                                                      AICommonBundle.message("settings.test.result.title"),
-                                                      JOptionPane.ERROR_MESSAGE);
+                        // [HOM-194] 用统一 helper 弹窗: 同时把详情写入 idea.log,
+                        // 并提供 "复制详情" / "Show Log" 两个辅助按钮
+                        showTestErrorDialog(result.getFullErrorMessage(), result.getThrowable());
                     }
                 });
             } catch (Exception e) {
@@ -501,10 +507,8 @@ public final class AIProviderConfigController {
                     configurationVerified = false;
                     updateTestButtonState();
                     removeAvailableProvider(testConfig.credentialId);
-                    JOptionPane.showMessageDialog(resolveDialogParent(),
-                                                  AICommonBundle.message("settings.test.connection.error", e.getMessage()),
-                                                  AICommonBundle.message("settings.test.result.title"),
-                                                  JOptionPane.ERROR_MESSAGE);
+                    showTestErrorDialog(
+                        AICommonBundle.message("settings.test.connection.error", e.getMessage()), e);
                 });
             } finally {
                 SwingUtilities.invokeLater(() -> {
@@ -513,6 +517,82 @@ public final class AIProviderConfigController {
                 });
             }
         });
+    }
+
+    /**
+     * 测试连接失败时展示统一弹窗
+     * <p>
+     * 同一处入口完成三件事:
+     * <ol>
+     *   <li>用 {@code log.warn} 写入 idea.log (slf4j → IDEA 自带 logger), 即使用户关掉弹窗,
+     *       详情仍然持久化, 方便用户事后 / 远程协助时定位</li>
+     *   <li>弹窗以 ERROR 样式展示完整错误 (含 HTTP status + body 摘要 + cause 信息)</li>
+     *   <li>提供 "复制详情" 一键 copy 到系统剪贴板, 用户可以直接贴到 GitHub issue;
+     *       "Show Log" 直接打开 idea.log 所在目录</li>
+     * </ol>
+     * 该方法只在 EDT 线程调用 (UI 操作).
+     *
+     * @param message 已经经过 {@code AIServiceException.build} / i18n 处理的用户可读错误描述,
+     *                可能跨多行, 不为 null
+     * @param cause   原始异常, 可为 null. 不为 null 时会和 message 一起写入 idea.log 的堆栈段
+     */
+    private void showTestErrorDialog(@NotNull String message, @Nullable Throwable cause) {
+        if (cause != null) {
+            log.warn("AI test connection failed: " + message, cause);
+        } else {
+            log.warn("AI test connection failed: " + message);
+        }
+
+        Object[] options = {"OK", "复制详情", "Show Log"};
+        int choice = JOptionPane.showOptionDialog(
+            resolveDialogParent(),
+            message,
+            AICommonBundle.message("settings.test.result.title"),
+            JOptionPane.DEFAULT_OPTION,
+            JOptionPane.ERROR_MESSAGE,
+            null,
+            options,
+            options[0]
+        );
+        if (choice == 1) {
+            try {
+                Toolkit.getDefaultToolkit().getSystemClipboard()
+                    .setContents(new StringSelection(message), null);
+            } catch (Throwable t) {
+                // 剪贴板异常 (如 headless / 权限) 仅记录, 不应再开第二个弹窗打断用户
+                log.warn("Failed to copy error detail to clipboard", t);
+            }
+        } else if (choice == 2) {
+            openLogFile();
+        }
+    }
+
+    /**
+     * 打开 idea.log 所在目录
+     * <p>
+     * 优先反射调用 {@code dev.dong4j.zeka.stack.idea.plugin.common.action.ShowLogAction#showLog()}
+     * (HOM-195 / Phase 3) 以便和插件菜单 + Find Action 入口保持一致. 但本 PR 基于
+     * dev 分支, Phase 3 PR (#81) 尚未合并, 所以做了降级: 直接用 {@link PathManager#getLogPath()}
+     * 拼接 idea.log 并交给 {@link RevealFileAction#openFile} 打开. 行为对用户等价,
+     * 等 HOM-195 合并后反射路径会自动接管, 无需再次改这里.
+     */
+    private static void openLogFile() {
+        try {
+            Class<?> clazz = Class.forName(
+                "dev.dong4j.zeka.stack.idea.plugin.common.action.ShowLogAction");
+            clazz.getDeclaredMethod("showLog").invoke(null);
+            return;
+        } catch (ClassNotFoundException ignored) {
+            // Phase 3 (HOM-195) 尚未合并, 走下面的降级路径
+        } catch (Throwable t) {
+            log.warn("Failed to call ShowLogAction.showLog(), falling back", t);
+        }
+        try {
+            File logFile = new File(PathManager.getLogPath(), "idea.log");
+            RevealFileAction.openFile(logFile);
+        } catch (Throwable t) {
+            log.warn("Failed to reveal idea.log", t);
+        }
     }
 
     /**

--- a/intelli-ai-engine/src/main/resources/messages/AICommonBundle.properties
+++ b/intelli-ai-engine/src/main/resources/messages/AICommonBundle.properties
@@ -33,12 +33,16 @@ settings.error.api.key.missing=API Key is required for this provider
 # AI Service Exception Messages
 error.ai.service.call.failed=AI service call failed: {0}
 error.ai.service.invalid.api.key=Invalid API Key. Please check and update your API Key in settings
+error.ai.service.invalid.api.key.with.detail=Invalid API Key. Please check and update your API Key in settings.\nDetails: {0}
 error.ai.service.rate.limit=Rate limit reached. Please try a different model
+error.ai.service.rate.limit.with.detail=Rate limit reached. Please try a different model.\nDetails: {0}
 error.ai.service.unavailable=AI service is temporarily unavailable. Please try again later
+error.ai.service.unavailable.with.detail=AI service is temporarily unavailable. Please try again later.\nDetails: {0}
 error.ai.service.network.error=Network connection failed. Please check your network connection or server address
 error.ai.service.configuration.error=Configuration error: {0}
 error.ai.service.api.key.required=API Key is required but not configured
 error.ai.service.invalid.response=Service returned invalid data format. The model name may be incorrect or the service is abnormal
+error.ai.service.invalid.response.with.detail=Service returned invalid data. The model name may be incorrect or the service is abnormal.\nDetails: {0}
 error.ai.service.call.failed.with.suggestion=AI service call failed. Try modifying the [Max Tokens] parameter?\n{0}
 error.ai.service.http.error=HTTP error: {0}
 freeai.statistics.required.title=FREEAI Unavailable


### PR DESCRIPTION
## 关联 Issue

- 父 issue: HOM-192 — [排查] 阿里百炼 minimax m2.5 模型 test 报错, 日志无法查看
- Phase 1 报告: HOM-193 — 已锁定根因
- 本 PR: HOM-194 — Phase 2 实施
- 并行: HOM-195 — Phase 3 日志可发现性 (PR #81)

Closes HOM-192

## 背景 (来自 Phase 1)

根因不是 \`reasoning_content\` 解析问题, 而是:
1. 模型名不含 \`think\` → \`enableThinking=false\` → 请求体写 \`enable_thinking: false\` → 阿里百炼直接返回 HTTP 400 \`The value of the enable_thinking parameter is restricted to True\`
2. HTTP 400 在 \`BlockingRequestExecutor\` 被映射为 \`INVALID_RESPONSE\`, 进而被 \`AIServiceException.build()\` 翻译成 \"服务返回的数据格式错误\" 这种通用文案, API 真实错误体彻底丢失

## 修改清单

| 文件 | 修改 |
|---|---|
| \`AICompatibleProvider.java\` | Fix 1: 永远不发送 \`enable_thinking: false\`, 移除非标准 \`think\` 字段 |
| \`BlockingRequestExecutor.java\` | Fix 2: 关闭 IDEA 自带 4xx 自动抛, 手动读 error stream + 截断 + 凭据脱敏; 400/404 映射到 \`CONFIGURATION_ERROR\`, 401/403 → \`INVALID_API_KEY\` |
| \`AIServiceException.java\` + \`AICommonBundle.properties\` | Fix 3: 新增 4 个 \`.with.detail\` bundle key, message 非空时拼接 detail, 否则回退原通用文案 (向后兼容) |
| \`AIProviderConfigController.java\` | Fix 4: 统一弹窗 helper, 同时 \`log.warn\` 写 idea.log; 加 \"复制详情\" / \"Show Log\" 两个按钮 |

## 验收 (对照 HOM-194 检查表)

- [x] \`AICompatibleProvider\` 不再发送 \`enable_thinking: false\` 和 \`think\` 字段
- [x] HTTP 4xx 的原始 response body 被保留并能在弹窗 + idea.log 里看到
- [x] Authorization / api_key / sk-xxx token 在透出前脱敏
- [x] 弹窗有 \"复制详情\" 按钮
- [x] commit message 包含 \`Closes HOM-192\`
- [ ] \`MiniMax-M2.5\` 和 \`MiniMax/MiniMax-M2.5\` 两种 model id 的 test 都通过 — **需在 IDE 中手动验证**

## 协作约定

- 与 Phase 3 (#81) 在 \`AIProviderConfigController.testConnection\` 有协作面. 我没有 import \`ShowLogAction\` (Phase 3 还未合并到 \`dev\`), 改用反射 + \`PathManager\` 降级方案: 反射调用 \`ShowLogAction.showLog()\` 成功就用它, 失败就直接 \`RevealFileAction.openFile\`. 等 HOM-195 合并后反射路径会自动接管, 行为对用户等价.
- Phase 3 合并后如有合并冲突, 由后合并方处理 (我俩都改了 \`AIProviderConfigController.testConnection\` 的弹窗逻辑; 我做了更彻底的重构, 建议在 Phase 3 已合并的前提下保留本 PR 的 helper 形式).

## 复现 (Phase 1 验证过的最小步骤)

- base URL: \`https://dashscope.aliyuncs.com/compatible-mode/v1\`
- 模型: \`MiniMax-M2.5\` 和 \`MiniMax/MiniMax-M2.5\`
- 期望: test 通过; 如果故意输错 API Key, 弹窗能看到 401 + 百炼原始错误文案, idea.log 同步有 warn 级别的完整记录

## 不在本 PR 范围

- Phase 3 的 \`ShowLogAction\` 注册 / 菜单 / Find Action 入口 / QUICK_START.md 文档更新 — 在 #81
- \`reasoning_content\` 解析路径 — Phase 1 已验证现有解析器完全兼容, 无需修改

Made with [Cursor](https://cursor.com)